### PR TITLE
Fix version of `bip32` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@tharsis/provider": "^0.2.4",
     "@tharsis/transactions": "^0.2.2",
     "axios": "^0.26.1",
-    "bip32": "^3.0.1",
+    "bip32": "3.0.1",
     "bip39": "^3.0.4",
     "canonical-json": "^0.0.4",
     "ethers": "^5.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1345,7 +1345,7 @@ bindings@^1.3.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bip32@^3.0.1:
+bip32@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/bip32/-/bip32-3.0.1.tgz#1d1121469cce6e910e0ec3a5a1990dd62687e2a3"
   integrity sha512-Uhpp9aEx3iyiO7CpbNGFxv9WcMIVdGoHG04doQ5Ln0u60uwDah7jUSc3QMV/fSZGm/Oo01/OeAmYevXV+Gz5jQ==


### PR DESCRIPTION
Fix package version for `bip32` as the next minor version doesn't work.

```
testecc.js?76e8:17 Uncaught TypeError: ecc.xOnlyPointAddTweak is not a function
    at Object.testEcc (testecc.js?76e8:17:1)
    at BIP32Factory (bip32.js?b5ed:9:1)
    at Object.eval (account.js?4e34:55:1)
    at eval (account.js?4e34:178:1)
    at ../../node_modules/@cerc-io/laconic-sdk/dist/account.js (cerc-io.bundle.js:11:1)
```